### PR TITLE
🐛 Missing shell

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ runs:
       uses: actions/checkout@v3
     - 
       continue-on-error: true
+      shell: bash
       id: check-changes
       name: "check if latest commit is within 24 hrs"
       run: "test -z $(git rev-list --after=\"24 hours\" ${{ github.sha }}) && echo \"::set-output name=changes::true\""


### PR DESCRIPTION
## Description
I've fixed a error that GitHub Actions complains about missing property 'shell'
You can check the following screenshot
You can also check the [Creating a composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action#creating-an-action-metadata-file) docs, the example it provides requires shell property exists.
## Error content
```
GitHub.DistributedTask.ObjectTemplating.TemplateValidationException: The template is not valid. lukecarr/nightly-check/v0.1.0/action.yml (Line: 16, Col: 7): Required property is missing: shell
   at GitHub.DistributedTask.ObjectTemplating.TemplateValidationErrors.Check()
   at GitHub.Runner.Worker.ActionManifestManager.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath, MappingToken outputs)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
```
## Screenshot
Error from GitHub Actions
![image](https://github.com/lukecarr/nightly-check/assets/33322926/1aac3193-dd17-4418-90f9-e70d02aa5f3e)
Error from linter
![image](https://github.com/lukecarr/nightly-check/assets/33322926/fc14377e-0cdd-4cbc-a3ff-1230ae89ac4d)

