### PR TITLE
📝 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.nightly-check.outputs.changes }}
     steps:
       - id: nightly-check
         name: Check for changes since last nightly

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ If you want to look for changes within a duration different to the default (24 h
 jobs:
   check:
     runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.nightly-check.outputs.changes }}
     steps:
       - id: nightly-check
-        name: Check for changes in last two days
+        name: Check for changes in the last two days
         uses: lukecarr/nightly-check@v0.2.0
         with:
           within: 48 hrs


### PR DESCRIPTION
## Description
According to GitHub Actions [document](https://docs.github.com/en/actions/learn-github-actions/contexts#example-usage-of-the-needs-context), we need to define output in jobs even step did write something to `GITHUB_OUTPUT` to make it accessible to next job.
